### PR TITLE
calculateNextDateByScheduleの隔週日付算出処理のバグ修正

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,2 +1,3 @@
 FROM node:12.1
+ENV WORKSPACE_DIR "/workspace"
 ENV PATH $PATH:./node_modules/.bin

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,10 +4,15 @@
 	"name": "Existing Dockerfile",
 
 	// Sets the run context to one level up instead of the .devcontainer folder.
-	"context": "..",
+	// "context": "..",
+	
 
 	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
-	"dockerFile": "Dockerfile",
+	// "dockerFile": "Dockerfile",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "node",
+	"shutdownAction": "stopCompose",
+	"workspaceFolder": "/workspace",
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
@@ -15,7 +20,7 @@
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": ["dbaeumer.vscode-eslint","ms-vscode.vscode-typescript-next"]
+	"extensions": ["dbaeumer.vscode-eslint","ms-vscode.vscode-typescript-next"],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
@@ -27,7 +32,7 @@
 	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
 
 	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-in-docker.
-	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+	// "mounts": [ "target=/node_modules,type=bind" ],
 
 	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+services: 
+  node:
+    build: .
+    volumes:
+      - ../:/workspace
+      - /workspace/node_modules
+    command: /bin/sh -c "while sleep 1000; do :; done"

--- a/dist/client/trash-schedule-service.js
+++ b/dist/client/trash-schedule-service.js
@@ -174,10 +174,10 @@ class TrashScheduleService {
      * @returns {Date} 条件に合致する直近の日にち
      */
     calculateNextDateBySchedule(today, schedule_type, schedule_val) {
-        const next_dt = new Date(today.getTime());
+        const recently_dt = new Date(today.getTime());
         if (schedule_type === 'weekday') {
             const diff_day = Number(schedule_val) - today.getDay();
-            diff_day < 0 ? next_dt.setDate(today.getDate() + (7 + diff_day)) : next_dt.setDate(today.getDate() + diff_day);
+            diff_day < 0 ? recently_dt.setDate(today.getDate() + (7 + diff_day)) : recently_dt.setDate(today.getDate() + diff_day);
         }
         else if (schedule_type === 'month') {
             let now_date = today.getDate();
@@ -186,14 +186,14 @@ class TrashScheduleService {
                 const diff_date = Number(schedule_val) - now_date;
                 if (diff_date < 0) {
                     // 現在日>設定日の場合は翌月の1日をセットする
-                    next_dt.setMonth(next_dt.getMonth() + 1);
-                    next_dt.setDate(1);
+                    recently_dt.setMonth(recently_dt.getMonth() + 1);
+                    recently_dt.setDate(1);
                 }
                 else {
                     // 現在日<設定日の場合は差分の分だけ日にちを進める
-                    next_dt.setDate(next_dt.getDate() + diff_date);
+                    recently_dt.setDate(recently_dt.getDate() + diff_date);
                 }
-                now_date = next_dt.getDate();
+                now_date = recently_dt.getDate();
             }
         }
         else if (schedule_type === 'biweek') {
@@ -204,20 +204,20 @@ class TrashScheduleService {
                 const turn = Number(matches[2]);
                 // 直近の同じ曜日の日にちを設定
                 const diff_day = weekday - today.getDay();
-                diff_day < 0 ? next_dt.setDate(today.getDate() + (7 + diff_day)) : next_dt.setDate(today.getDate() + diff_day);
+                diff_day < 0 ? recently_dt.setDate(today.getDate() + (7 + diff_day)) : recently_dt.setDate(today.getDate() + diff_day);
                 // 何週目かを求める
                 let nowturn = 0;
-                let targetdate = next_dt.getDate();
+                let targetdate = recently_dt.getDate();
                 while (targetdate > 0) {
                     nowturn += 1;
                     targetdate -= 7;
                 }
-                let current_month = next_dt.getMonth();
+                let current_month = recently_dt.getMonth();
                 while (turn != nowturn) {
-                    next_dt.setDate(next_dt.getDate() + 7);
-                    if (current_month != next_dt.getMonth()) {
+                    recently_dt.setDate(recently_dt.getDate() + 7);
+                    if (current_month != recently_dt.getMonth()) {
                         nowturn = 1;
-                        current_month = next_dt.getMonth();
+                        current_month = recently_dt.getMonth();
                     }
                     else {
                         nowturn += 1;
@@ -234,24 +234,27 @@ class TrashScheduleService {
             start_dt.setMinutes(0);
             start_dt.setSeconds(0);
             start_dt.setMilliseconds(0);
-            // 直近の同じ曜日の日にちを設定
+            // 直近の同じ曜日の日にちを設定する
             const diff_date = Number(evweek_val.weekday) - today.getDay();
-            diff_date < 0 ? next_dt.setDate(today.getDate() + (7 + diff_date)) : next_dt.setDate(today.getDate() + diff_date);
+            diff_date < 0 ? recently_dt.setDate(today.getDate() + (7 + diff_date)) : recently_dt.setDate(today.getDate() + diff_date);
             // 直近の同じ曜日の日にちの日曜日を取得
-            const current_dt = new Date(next_dt.getTime());
-            current_dt.setHours(0);
-            current_dt.setMinutes(0);
-            current_dt.setSeconds(0);
-            current_dt.setMilliseconds(0);
-            current_dt.setDate(current_dt.getDate() - current_dt.getDay());
+            const recently_sunday_dt = new Date(recently_dt.getTime());
+            recently_sunday_dt.setHours(0);
+            recently_sunday_dt.setMinutes(0);
+            recently_sunday_dt.setSeconds(0);
+            recently_sunday_dt.setMilliseconds(0);
+            recently_sunday_dt.setDate(recently_sunday_dt.getDate() - recently_sunday_dt.getDay());
             // 登録されている日付からの経過日数を求める
-            const past_date = (current_dt.getTime() - start_dt.getTime()) / 1000 / 60 / 60 / 24;
-            // 差が0以外かつあまりが0でなければ1週間進める
-            if (past_date != 0 && (past_date / 7) % evweek_val.interval != 0) {
-                next_dt.setDate(next_dt.getDate() + (7 * (evweek_val.interval - (Math.abs(past_date / 7)))));
+            // 開始日＞判定対象日の場合を考慮して経過日数は絶対値に変換する
+            // (経過日数はこの後の日にちを進める週数判定に利用するため、経過日数がマイナスだと計算結果が誤りとなるため)
+            const past_date = Math.abs((recently_sunday_dt.getTime() - start_dt.getTime()) / 1000 / 60 / 60 / 24);
+            // 経過日数≠0かつ開始日からの経過日数/インターバルの余りが≠0であれば直近の同じ曜日は該当週ではないので、そこからインターバル分日にちを進める
+            const mod_of_interval = (past_date / 7) % evweek_val.interval;
+            if (past_date != 0 && mod_of_interval != 0) {
+                recently_dt.setDate(recently_dt.getDate() + (7 * (evweek_val.interval - mod_of_interval)));
             }
         }
-        return next_dt;
+        return recently_dt;
     }
     /*
     指定したごみの種類から直近のゴミ捨て日を求める

--- a/package-lock.json
+++ b/package-lock.json
@@ -2720,7 +2720,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "har-schema": {
       "version": "2.0.0",
@@ -3174,6 +3175,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -4476,6 +4478,7 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -4680,6 +4683,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -4694,6 +4698,7 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -4703,6 +4708,7 @@
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -5552,7 +5558,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -6304,7 +6311,8 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
       "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "v8-compile-cache": {
       "version": "2.1.0",
@@ -6515,16 +6523,17 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "yargs": {
       "version": "15.4.1",


### PR DESCRIPTION
type:evweekの開始日の翌々月以降に過去日を返すバグを修正

テストコード修正:
・NICTのNTP APIがHTTPで提供停止されたため代替のWorldTimeApiに変更した
・隔週設定で月をまたぐケースの追加
  - calculateNextDayBySchedule
  - getDayByTrashType

その他:
・node_modulesをRemoteContainerのマウントから外す